### PR TITLE
Only clicking on Force Publish should call the GraphQl mutation, canceling and exiting the dialog should do nothing.

### DIFF
--- a/src/javascript/ForcePublishAll/ForcePublishAll/ForcePublishAll.jsx
+++ b/src/javascript/ForcePublishAll/ForcePublishAll/ForcePublishAll.jsx
@@ -5,7 +5,7 @@ import {Button} from '@jahia/moonstone';
 
 const ForcePublishAll = ({onClose, onExit, isOpen, path}) => {
     return (
-            <Dialog fullWidth open={isOpen} aria-labelledby="form-dialog-title" data-cm-role="export-options" onExited={onExit} onClose={onClose}>
+            <Dialog fullWidth open={isOpen} aria-labelledby="form-dialog-title" data-cm-role="export-options" onExited={onExit} onClose={onExit}>
                 <DialogTitle>
                     Force Publish All
                 </DialogTitle>
@@ -15,7 +15,7 @@ const ForcePublishAll = ({onClose, onExit, isOpen, path}) => {
                     </FormHelperText>
                 </DialogContent>
                 <DialogActions>
-                    <Button size="big" label="Cancel" onClick={onClose}/>
+                    <Button size="big" label="Cancel" onClick={onExit}/>
                     <Button
                         size="big"
                         color="accent"


### PR DESCRIPTION
Only clicking on **Force Publish** publish should call the GraphQl mutation, canceling and exiting should do nothing.

I also suggest methods renaming later.

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/PROJECT-XXX

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests


**Test case : before**
- Click cancel 
- Check the logs and find that there are some logs and the force publish was executed while we just click Cancel

- Exit the dialog by clicking outside
- Check the logs and find that there are some logs and the force publish was executed while we just click Cancel

**Test case : after**
- Click cancel 
- check the logs
- no unpublish and then publish was executed

Also 
- Exit the dialog by clicking outside
- Check the logs
- No unpublish and then publish was executed

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
